### PR TITLE
make code run again and indent

### DIFF
--- a/cookbooks/extension_with_melt/extension_with_melt.cc
+++ b/cookbooks/extension_with_melt/extension_with_melt.cc
@@ -48,9 +48,9 @@ namespace aspect
   {
     template <int dim>
     MeltingRateFunction<dim>::MeltingRateFunction ()
-    :
-    function (1)
-  {}
+      :
+      function (1)
+    {}
 
 
     template <int dim>
@@ -86,13 +86,13 @@ namespace aspect
       if (in.cell && this->get_timestep_number() > 0)
         {
           for (unsigned int q=0; q < in.position.size(); ++q)
-              for (unsigned int c=0; c<in.composition[q].size(); ++c)
-                {
-                  if (c == porosity_idx)
-                    out.reaction_terms[q][c] = function.value(in.position[q]) / time_scale * out.densities[q];
-                  else if (c == peridotite_idx)
-                    out.reaction_terms[q][c] = 0.0;
-                }
+            for (unsigned int c=0; c<in.composition[q].size(); ++c)
+              {
+                if (c == porosity_idx)
+                  out.reaction_terms[q][c] = function.value(in.position[q]) / time_scale * out.densities[q];
+                else if (c == peridotite_idx)
+                  out.reaction_terms[q][c] = 0.0;
+              }
         }
     }
 
@@ -131,48 +131,48 @@ namespace aspect
     {
       prm.enter_subsection("Material model");
       {
-          prm.enter_subsection("Melting rate function");
-          {
-              AssertThrow( prm.get("Base model") != "melting rate function",
-                           ExcMessage("You may not use ``depth dependent'' as the base model for "
-                                      "a depth-dependent model.") );
+        prm.enter_subsection("Melting rate function");
+        {
+          AssertThrow( prm.get("Base model") != "melting rate function",
+                       ExcMessage("You may not use ``depth dependent'' as the base model for "
+                                  "a depth-dependent model.") );
 
-              // create the base model and initialize its SimulatorAccess base
-              // class; it will get a chance to read its parameters below after we
-              // leave the current section
-              base_model.reset(create_material_model<dim>(prm.get("Base model")));
-              if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
-                sim->initialize_simulator (this->get_simulator());
+          // create the base model and initialize its SimulatorAccess base
+          // class; it will get a chance to read its parameters below after we
+          // leave the current section
+          base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
+            sim->initialize_simulator (this->get_simulator());
 
-              prm.enter_subsection("Function");
-              try
-                {
-                  function.parse_parameters (prm);
-                }
-              catch (...)
-                {
-                  std::cerr << "ERROR: FunctionParser failed to parse\n"
-                            << "\t'Material model.Melting rate function.Function'\n"
-                            << "with expression\n"
-                            << "\t'" << prm.get("Function expression") << "'"
-                            << "More information about the cause of the parse error \n"
-                            << "is shown below.\n";
-                  throw;
-                }
-              prm.leave_subsection();
-          }
+          prm.enter_subsection("Function");
+          try
+            {
+              function.parse_parameters (prm);
+            }
+          catch (...)
+            {
+              std::cerr << "ERROR: FunctionParser failed to parse\n"
+                        << "\t'Material model.Melting rate function.Function'\n"
+                        << "with expression\n"
+                        << "\t'" << prm.get("Function expression") << "'"
+                        << "More information about the cause of the parse error \n"
+                        << "is shown below.\n";
+              throw;
+            }
           prm.leave_subsection();
         }
         prm.leave_subsection();
+      }
+      prm.leave_subsection();
 
-        /* After parsing the parameters for depth dependent, it is essential to parse
-        parameters related to the base model. */
-        base_model->parse_parameters(prm);
-        this->model_dependence = base_model->get_model_dependence();
+      /* After parsing the parameters for depth dependent, it is essential to parse
+      parameters related to the base model. */
+      base_model->parse_parameters(prm);
+      this->model_dependence = base_model->get_model_dependence();
 
-        AssertThrow(this->introspection().compositional_name_exists("porosity"),
-                    ExcMessage("Material model melting rate function only "
-                               "works if there is a compositional field called porosity."));
+      AssertThrow(this->introspection().compositional_name_exists("porosity"),
+                  ExcMessage("Material model melting rate function only "
+                             "works if there is a compositional field called porosity."));
     }
   }
 }

--- a/cookbooks/keller_2013/keller_2013.cc
+++ b/cookbooks/keller_2013/keller_2013.cc
@@ -49,9 +49,9 @@ namespace aspect
   {
     template <int dim>
     MeltingRateFunction<dim>::MeltingRateFunction ()
-    :
-    function (1)
-  {}
+      :
+      function (1)
+    {}
 
 
     template <int dim>
@@ -96,7 +96,7 @@ namespace aspect
                     out.reaction_terms[q][c] = 0.0;
                 }
               out.viscosities[q] *= (1.0 - in.composition[q][porosity_idx]);
-          }
+            }
         }
 
       // fill melt outputs if they exist
@@ -146,48 +146,48 @@ namespace aspect
     {
       prm.enter_subsection("Material model");
       {
-          prm.enter_subsection("Melting rate function");
-          {
-              AssertThrow( prm.get("Base model") != "melting rate function",
-                           ExcMessage("You may not use ``depth dependent'' as the base model for "
-                                      "a depth-dependent model.") );
+        prm.enter_subsection("Melting rate function");
+        {
+          AssertThrow( prm.get("Base model") != "melting rate function",
+                       ExcMessage("You may not use ``depth dependent'' as the base model for "
+                                  "a depth-dependent model.") );
 
-              // create the base model and initialize its SimulatorAccess base
-              // class; it will get a chance to read its parameters below after we
-              // leave the current section
-              base_model.reset(create_material_model<dim>(prm.get("Base model")));
-              if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
-                sim->initialize_simulator (this->get_simulator());
+          // create the base model and initialize its SimulatorAccess base
+          // class; it will get a chance to read its parameters below after we
+          // leave the current section
+          base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
+            sim->initialize_simulator (this->get_simulator());
 
-              prm.enter_subsection("Function");
-              try
-                {
-                  function.parse_parameters (prm);
-                }
-              catch (...)
-                {
-                  std::cerr << "ERROR: FunctionParser failed to parse\n"
-                            << "\t'Material model.Melting rate function.Function'\n"
-                            << "with expression\n"
-                            << "\t'" << prm.get("Function expression") << "'"
-                            << "More information about the cause of the parse error \n"
-                            << "is shown below.\n";
-                  throw;
-                }
-              prm.leave_subsection();
-          }
+          prm.enter_subsection("Function");
+          try
+            {
+              function.parse_parameters (prm);
+            }
+          catch (...)
+            {
+              std::cerr << "ERROR: FunctionParser failed to parse\n"
+                        << "\t'Material model.Melting rate function.Function'\n"
+                        << "with expression\n"
+                        << "\t'" << prm.get("Function expression") << "'"
+                        << "More information about the cause of the parse error \n"
+                        << "is shown below.\n";
+              throw;
+            }
           prm.leave_subsection();
         }
         prm.leave_subsection();
+      }
+      prm.leave_subsection();
 
-        /* After parsing the parameters for depth dependent, it is essential to parse
-        parameters related to the base model. */
-        base_model->parse_parameters(prm);
-        this->model_dependence = base_model->get_model_dependence();
+      /* After parsing the parameters for depth dependent, it is essential to parse
+      parameters related to the base model. */
+      base_model->parse_parameters(prm);
+      this->model_dependence = base_model->get_model_dependence();
 
-        AssertThrow(this->introspection().compositional_name_exists("porosity"),
-                    ExcMessage("Material model melting rate function only "
-                               "works if there is a compositional field called porosity."));
+      AssertThrow(this->introspection().compositional_name_exists("porosity"),
+                  ExcMessage("Material model melting rate function only "
+                             "works if there is a compositional field called porosity."));
     }
   }
 }

--- a/include/aspect/elastic.h
+++ b/include/aspect/elastic.h
@@ -38,7 +38,7 @@ namespace aspect
     {
       public:
         ElasticOutputs (const unsigned int n_points,
-                     const unsigned int /*n_comp*/)
+                        const unsigned int /*n_comp*/)
         {
           elastic_viscosities.resize(n_points);
           elastic_evolutions.resize(n_points);
@@ -62,10 +62,10 @@ namespace aspect
          * The projection matrix argument is only used if the operation
          * chosen is project_to_Q1.
          */
-       /** void average (const MaterialAveraging::AveragingOperation operation,
-        *              const FullMatrix<double>  &projection_matrix,
-        *             const FullMatrix<double>  &expansion_matrix);
-        */
+        /** void average (const MaterialAveraging::AveragingOperation operation,
+         *              const FullMatrix<double>  &projection_matrix,
+         *             const FullMatrix<double>  &expansion_matrix);
+         */
     };
 
   }

--- a/include/aspect/material_model/melt_visco_plastic.h
+++ b/include/aspect/material_model/melt_visco_plastic.h
@@ -22,7 +22,6 @@
 #define _aspect_material_model_melt_visco_plastic_h
 
 #include <aspect/material_model/interface.h>
-#include <aspect/material_model/diffusion_dislocation.h>
 #include <aspect/postprocess/melt_statistics.h>
 #include <aspect/melt.h>
 #include <aspect/elastic.h>
@@ -53,7 +52,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class MeltViscoPlastic : public MaterialModel::DiffusionDislocation<dim>, public MaterialModel::MeltFractionModel<dim>
+    class MeltViscoPlastic : public MaterialModel::MeltFractionModel<dim>, public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
         /**
@@ -80,6 +79,8 @@ namespace aspect
          * @{
          */
         virtual double reference_viscosity () const;
+
+        virtual double reference_darcy_coefficient () const;
 
         virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
                               typename Interface<dim>::MaterialModelOutputs &out) const;
@@ -187,6 +188,12 @@ namespace aspect
         double
         melt_fraction (const double temperature,
                        const double pressure) const;
+
+
+        /**
+         * Pointer to the material model used as the base model
+         */
+        std_cxx11::shared_ptr<MaterialModel::Interface<dim> > base_model;
     };
 
   }

--- a/source/boundary_fluid_pressure/density.cc
+++ b/source/boundary_fluid_pressure/density.cc
@@ -67,7 +67,7 @@ namespace aspect
                 const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
                 const double porosity = std::min(1.0, std::max(material_model_inputs.composition[q][porosity_idx],0.0));
                 const double average_density = porosity * melt_outputs->fluid_densities[q]
-                                             + (1.0 - porosity) * material_model_outputs.densities[q];
+                                               + (1.0 - porosity) * material_model_outputs.densities[q];
                 fluid_pressure_gradient_outputs[q] = (average_density * gravity) * normal_vectors[q];
                 break;
               }


### PR DESCRIPTION
@naliboff @anne-glerum 
After the rebase, we now can no longer derive the material model from diffusion dislocation (during the hackathon, we added the new MeltInterface, which made models with this material model and melt transport crash). I changed this to now instead use a base model that can be chosen in the input file, and this also makes everything a bit more flexible. With this change, models with melt run again (but I haven't tested if everything works exactly as before). 