### PR TITLE
Refactor some parameters

### DIFF
--- a/include/aspect/material_model/rheology/drucker_prager.h
+++ b/include/aspect/material_model/rheology/drucker_prager.h
@@ -51,17 +51,6 @@ namespace aspect
          * Limit maximum yield stress from drucker prager yield criterion.
          */
         double max_yield_stress;
-
-        /**
-         * Whether to add a plastic damper in the computation
-         * of the drucker prager plastic viscosity.
-         */
-        bool use_plastic_damper;
-
-        /**
-         * Viscosity of a damper used to stabilize plasticity
-         */
-        double damper_viscosity;
       };
 
       template <int dim>
@@ -108,9 +97,7 @@ namespace aspect
                              const double pressure,
                              const double effective_strain_rate,
                              const double max_yield_stress,
-                             const bool use_plastic_damper,
-                             const double damper_viscosity,
-                             const double pre_yield_viscosity) const;
+                             const double pre_yield_viscosity = std::numeric_limits<double>::infinity()) const;
 
           /**
            * Compute the derivative of the plastic viscosity with respect to pressure.
@@ -118,6 +105,18 @@ namespace aspect
           double
           compute_derivative (const double angle_internal_friction,
                               const double effective_strain_rate) const;
+
+        private:
+          /**
+           * Whether to add a plastic damper in the computation
+           * of the drucker prager plastic viscosity.
+           */
+          bool use_plastic_damper;
+
+          /**
+           * Viscosity of a damper used to stabilize plasticity
+           */
+          double damper_viscosity;
       };
     }
   }

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -109,9 +109,6 @@ namespace aspect
                                                                                          angle_of_internal_friction,
                                                                                          pressure,
                                                                                          std::sqrt(strain_rate_effective),
-                                                                                         std::numeric_limits<double>::infinity(),
-                                                                                         false,
-                                                                                         0.0,
                                                                                          std::numeric_limits<double>::infinity());
 
                   const double viscosity_pressure_derivative = drucker_prager_plasticity.compute_derivative(angle_of_internal_friction,std::sqrt(strain_rate_effective));

--- a/source/material_model/dynamic_friction.cc
+++ b/source/material_model/dynamic_friction.cc
@@ -62,9 +62,6 @@ namespace aspect
                                                                                        phi,
                                                                                        std::max(pressure,0.0),
                                                                                        std::sqrt(strain_rate_dev_inv2),
-                                                                                       std::numeric_limits<double>::infinity(),
-                                                                                       false,
-                                                                                       0.0,
                                                                                        std::numeric_limits<double>::infinity());
 
           // Cut off the viscosity between a minimum and maximum value to avoid

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -59,8 +59,6 @@ namespace aspect
                                              const double pressure,
                                              const double effective_strain_rate,
                                              const double max_yield_stress,
-                                             const bool use_plastic_damper,
-                                             const double damper_viscosity,
                                              const double pre_yield_viscosity) const
       {
         const double yield_stress = compute_yield_stress(cohesion, angle_internal_friction, pressure, max_yield_stress);
@@ -168,10 +166,10 @@ namespace aspect
         parameters.max_yield_stress = prm.get_double("Maximum yield stress");
 
         // Whether to include a plastic damper when computing the drucker-prager plastic viscosity
-        parameters.use_plastic_damper = prm.get_bool("Use plastic damper");
+        use_plastic_damper = prm.get_bool("Use plastic damper");
 
         // Stabalize plasticity through a viscous damper
-        parameters.damper_viscosity = prm.get_double("Plastic damper viscosity");
+        damper_viscosity = prm.get_double("Plastic damper viscosity");
 
         return parameters;
       }

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -369,8 +369,6 @@ namespace aspect
                                                                                   pressure_for_plasticity,
                                                                                   current_edot_ii,
                                                                                   drucker_prager_parameters.max_yield_stress,
-                                                                                  drucker_prager_parameters.use_plastic_damper,
-                                                                                  drucker_prager_parameters.damper_viscosity,
                                                                                   viscosity_pre_yield);
                     composition_yielding[j] = true;
                   }


### PR DESCRIPTION
These are the changes I discussed in https://github.com/geodynamics/aspect/pull/3473/files#issuecomment-733941922.
I know we want to refactor the rheology plugin separately, but I thought we do not have to add to a mistake we made earlier by putting more parameters into the separate parameter object. I also added a default parameter to allow the drucker_prager material model and the dynamic_friction material model to remain unchanged.

Do you think these changes make sense? 